### PR TITLE
PerimeterX Validation

### DIFF
--- a/PCFSwift/Sources/Alamofire/HTTPClient+Alamofire.swift
+++ b/PCFSwift/Sources/Alamofire/HTTPClient+Alamofire.swift
@@ -9,6 +9,13 @@
 import Alamofire
 
 public extension HTTPClient {
+    
+    func validStatusCodes() -> [Int] {
+        var codes: [Int] = Array(200..<300)
+        // Need to add 403 status code to allow PerimeterX Bot detector to block illegitimate request
+        codes.append(403)
+        return codes
+    }
 
     public func perform(request: HTTPRequest,
                         completion: @escaping (_ response: HTTPResponse?, _ error: Swift.Error?) -> Void) {
@@ -17,7 +24,7 @@ public extension HTTPClient {
                           parameters: request.parameters,
                           encoding: JSONEncoding.default,
                           headers: request.headers)
-            .validate()
+            .validate(statusCode: validStatusCodes())
             .responseJSON { (response: DataResponse<Any>) in
                 
                 #if DEBUG


### PR DESCRIPTION
Status code validation is managed by HTTPClient, but the status code 403 being an invalid status code is required for us to catch the bots.

All the request are served by perform method in HTTPClient through KillSwitchCheckingHTTPClient perform method. KillSwitchCheckingHTTPClient manages the http request for entire app.

403 status code is handled by KillSwitchCheckingHTTPClient to check if the request has been made by human or bots and validate it accordingly.

It uses PerimeterX framework to do the bot validation. So, Added 403 as a valid status code to allow PerimeterX to validate the API request.